### PR TITLE
Add remember-me login and greet users by name

### DIFF
--- a/5.html
+++ b/5.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no' name='viewport' />
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:400,700|Material+Icons" />
-    <link rel="preload" as="style" href="/build/dashboard.css" /><link rel="stylesheet" href="build/dashboard.css" data-navigate-track="reload" />    </head>
+    <link rel="preload" as="style" href="build/assets/dashboard.css" /><link rel="stylesheet" href="build/assets/dashboard.css" data-navigate-track="reload" />    </head>
 
 <body class="">
     <script>document.querySelector('body').classList.add(localStorage.getItem('body') === 'dark-only' ? 'dark-only' : 'default');</script>
@@ -32,21 +32,19 @@
                    autoplay
     />
 </div>
-            <form id="logout-form" action="https://cienciadedados.unicv.edu.br/logout" method="POST" style="display: none;">
-            <input type="hidden" name="_token" value="lvZ2umWn1Kr8WsDLuis8QRNCGWmrF0q5OySqzNJB" autocomplete="off">        </form>
         <div id="pageWrapper" class="page-wrapper compact-wrapper">
     <!-- Navbar -->
 <nav class="page-main-header">
         <div class="main-header-right row m-0">
         <div class="main-header-left">
             <div class="logo-wrapper w-50">
-                <a href="https://cienciadedados.unicv.edu.br">
-                    <img class="img-fluid" src="https://cienciadedados.unicv.edu.br/assets/images/logo/row.png" alt="">
+                <a href="index.html">
+                    <img class="img-fluid" src="assets/images/logo/row.png" alt="">
                 </a>
             </div>
             <div class="dark-logo-wrapper w-50">
-                <a href="https://cienciadedados.unicv.edu.br">
-                    <img class="img-fluid" src="https://cienciadedados.unicv.edu.br/assets/images/logo/white-row.png" alt="">
+                <a href="index.html">
+                    <img class="img-fluid" src="assets/images/logo/white-row.png" alt="">
                 </a>
             </div>
             <div class="toggle-sidebar">
@@ -116,18 +114,16 @@
     <div class="page-body-wrapper">
         <header class="main-nav">
     <div class="sidebar-user text-center">
-        <a title="Editar perfil" class="setting-primary" href="https://cienciadedados.unicv.edu.br/perfil">
+        <a title="Editar perfil" class="setting-primary" href="perfil.html">
             <i data-feather="settings"></i>
         </a>
-                <a title="Sair" class="setting-secondary"
-            onclick="event.preventDefault();document.getElementById('logout-form').submit();"
-            href="https://cienciadedados.unicv.edu.br/logout">
+                <a title="Sair" class="setting-secondary" href="#" onclick="handleLogout()">
             <i data-feather="log-out"></i>
         </a>
         <img class="rounded-circle img-90" style="object-fit: cover;"
-            src="https://cienciadedados.unicv.edu.br/perfil/119/foto">
-        <a href="https://cienciadedados.unicv.edu.br/perfil">
-            <h6 class="mt-3 f-14 f-w-600">Gabriel França Dutra Simões</h6>
+            src="perfil/119/foto">
+        <a href="perfil.html">
+            <h6 class="mt-3 f-14 f-w-600 user-name"></h6>
         </a>
         <p class="mb-0 font-roboto">T.I</p>
             </div>
@@ -142,7 +138,7 @@
                     </li>
                     <li class="dropdown ">
     <a class="nav-link menu-title link-nav "
-        href="https://cienciadedados.unicv.edu.br">
+        href="index.html">
         <i data-feather="home"></i>
         <span>Painel inicial</span>
     </a>
@@ -182,7 +178,7 @@
             <div class="col-lg-6">
                 <h3>Relatório Acompanhamento de Leads e Vendas GRC</h3>
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="https://cienciadedados.unicv.edu.br">Página inicial</a></li>
+                    <li class="breadcrumb-item"><a href="index.html">Página inicial</a></li>
                     
                 </ol>
             </div>
@@ -215,7 +211,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" integrity="sha512-pHVGpX7F/27yZ0ISY+VVjyULApbDlD0/X0rgGbTqCE7WFW5MezNTWG/dnhtbBuICzsd0WQPgpE4REBLv+UqChw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <link rel="modulepreload" href="https://cienciadedados.unicv.edu.br/build/assets/app.ab25a034.js" /><script type="module" src="https://cienciadedados.unicv.edu.br/build/assets/app.ab25a034.js" data-navigate-track="reload"></script>        <script>
+    <script src="assets/js/auth.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            requireAuth();
+        });
+    </script>
+    <link rel="modulepreload" href="build/assets/dashboard.js" /><script type="module" src="build/assets/dashboard.js" data-navigate-track="reload"></script>        <script>
         document.addEventListener('DOMContentLoaded', () => {
             fadeOutToRight();
 

--- a/DIR_DE_OPERACOES_COMERCIAIS.html
+++ b/DIR_DE_OPERACOES_COMERCIAIS.html
@@ -32,8 +32,6 @@
                    autoplay
     />
 </div>
-            <form id="logout-form" action="login.html" method="POST" style="display: none;">
-            <input type="hidden" name="_token" value="lvZ2umWn1Kr8WsDLuis8QRNCGWmrF0q5OySqzNJB" autocomplete="off">        </form>
         <div id="pageWrapper" class="page-wrapper compact-wrapper">
     <!-- Navbar -->
 <nav class="page-main-header">
@@ -119,15 +117,13 @@
         <a title="Editar perfil" class="setting-primary" href="perfil.html">
             <i data-feather="settings"></i>
         </a>
-                <a title="Sair" class="setting-secondary"
-            onclick="event.preventDefault();document.getElementById('logout-form').submit();"
-            href="login.html">
+                <a title="Sair" class="setting-secondary" href="#" onclick="handleLogout()">
             <i data-feather="log-out"></i>
         </a>
         <img class="rounded-circle img-90" style="object-fit: cover;"
             src="perfil/119/foto">
         <a href="perfil.html">
-            <h6 class="mt-3 f-14 f-w-600">Gabriel França Dutra Simões</h6>
+            <h6 class="mt-3 f-14 f-w-600 user-name"></h6>
         </a>
         <p class="mb-0 font-roboto">T.I</p>
             </div>
@@ -257,6 +253,12 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" integrity="sha512-pHVGpX7F/27yZ0ISY+VVjyULApbDlD0/X0rgGbTqCE7WFW5MezNTWG/dnhtbBuICzsd0WQPgpE4REBLv+UqChw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="assets/js/auth.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            requireAuth();
+        });
+    </script>
     <link rel="modulepreload" href="build/assets/dashboard.js" /><script type="module" src="build/assets/dashboard.js" data-navigate-track="reload"></script>        <script>
         document.addEventListener('DOMContentLoaded', () => {
             fadeOutToRight();

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,0 +1,91 @@
+const Auth = {
+  defaultUsers: [
+    { email: 'gabriel.simoes@unicv.edu.br', password: 'Mudar@123', name: 'Gabriel França Dutra Simões' },
+    { email: 'noelle.martins@unicv.edu.br', password: 'Mudar@123', name: 'Noelle Naira Izidoro Portes Martins' }
+  ],
+  getUsers() {
+    const data = localStorage.getItem('users');
+    if (data) {
+      try {
+        return JSON.parse(data);
+      } catch (e) {
+        // fall through to reset on parse error
+      }
+    }
+    localStorage.setItem('users', JSON.stringify(this.defaultUsers));
+    return [...this.defaultUsers];
+  },
+  setUsers(users) {
+    localStorage.setItem('users', JSON.stringify(users));
+  },
+  login(email, password, remember = false) {
+    const users = this.getUsers();
+    const user = users.find(u => u.email === email && u.password === password);
+    if (user) {
+      const authData = JSON.stringify({ email: user.email, name: user.name });
+      sessionStorage.setItem('auth', authData);
+      if (remember) {
+        localStorage.setItem('auth', authData);
+      } else {
+        localStorage.removeItem('auth');
+      }
+      return true;
+    }
+    return false;
+  },
+  changePassword(oldPassword, newPassword) {
+    const auth = this.getUser();
+    if (!auth) return false;
+    const users = this.getUsers();
+    const user = users.find(u => u.email === auth.email);
+    if (user && user.password === oldPassword) {
+      user.password = newPassword;
+      this.setUsers(users);
+      return true;
+    }
+    return false;
+  },
+  logout() {
+    sessionStorage.removeItem('auth');
+    localStorage.removeItem('auth');
+  },
+  isLoggedIn() {
+    return !!this.getUser();
+  },
+  getUser() {
+    let data = sessionStorage.getItem('auth');
+    if (!data) {
+      data = localStorage.getItem('auth');
+      if (data) {
+        sessionStorage.setItem('auth', data);
+      }
+    }
+    return data ? JSON.parse(data) : null;
+  }
+};
+
+window.Auth = Auth;
+
+function requireAuth() {
+  if (!Auth.isLoggedIn()) {
+    window.location.href = 'login.html';
+  } else {
+    const user = Auth.getUser();
+    document.querySelectorAll('.user-name').forEach(el => {
+      if (user && el) el.textContent = user.name;
+    });
+    const inputName = document.getElementById('input-name');
+    if (user && inputName) {
+      inputName.value = user.name;
+    }
+    const inputEmail = document.getElementById('input-email');
+    if (user && inputEmail) {
+      inputEmail.value = user.email;
+    }
+  }
+}
+
+function handleLogout() {
+  Auth.logout();
+  window.location.href = 'login.html';
+}

--- a/index.html
+++ b/index.html
@@ -32,8 +32,7 @@
                    autoplay
     />
 </div>
-            <a href="login.html" class="btn btn-danger">Sair</a>
-            <input type="hidden" name="_token" value="NwprRc9Mmjit8sKmOihrWkv9ujf3Z09bA03YbcHP" autocomplete="off">        </form>
+            <a href="#" class="btn btn-danger" onclick="handleLogout()">Sair</a>
         <div id="pageWrapper" class="page-wrapper compact-wrapper">
     <!-- Navbar -->
 <nav class="page-main-header">
@@ -90,12 +89,12 @@
         <a title="Editar perfil" class="setting-primary" href="perfil.html">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-settings"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
         </a>
-                <a title="Sair" class="setting-secondary" onclick="event.preventDefault();document.getElementById('logout-form').submit();" href="login.html">
+                <a title="Sair" class="setting-secondary" href="#" onclick="handleLogout()">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-log-out"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
         </a>
         <img class="rounded-circle img-90" style="object-fit: cover;" src="perfil/119/foto">
         <a href="perfil.html">
-            <h6 class="mt-3 f-14 f-w-600">Gabriel França Dutra Simões</h6>
+            <h6 class="mt-3 f-14 f-w-600 user-name"></h6>
         </a>
         <p class="mb-0 font-roboto">T.I</p>
             </div>
@@ -158,7 +157,7 @@
     </div>
 </div>
             <div class="card card-body">
-                <h5>Olá, Gabriel França Dutra Simões</h5>
+                <h5>Olá, <span class="user-name"></span>.</h5>
                                     <p>Escolha um relatório no menu lateral</p>
                             </div>
         </div>
@@ -186,6 +185,12 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" integrity="sha512-pHVGpX7F/27yZ0ISY+VVjyULApbDlD0/X0rgGbTqCE7WFW5MezNTWG/dnhtbBuICzsd0WQPgpE4REBLv+UqChw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="assets/js/auth.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            requireAuth();
+        });
+    </script>
     <link rel="modulepreload" href="build/assets/dashboard.js" /><script type="module" src="build/assets/dashboard.js" data-navigate-track="reload"></script>        <script>
         document.addEventListener('DOMContentLoaded', () => {
             fadeOutToRight();

--- a/login.html
+++ b/login.html
@@ -63,7 +63,7 @@
             <div class="row">
                 <div class="col-12">
                     <div class="login-card" style="display: flex; flex-direction: column;">
-                        <form class="theme-form login-form" onsubmit="event.preventDefault(); window.location.href='index.html';">
+                        <form id="login-form" class="theme-form login-form">
                             <input type="hidden" name="_token" value="sqB15Y0aDfF1NARRNCWCriGdV2dFoBFEjZNVqUbA" autocomplete="off">                            <img src="assets/images/logo/row.png"
                                  alt="Logo do UniCV"
                                  class="d-block mx-auto mt-0 mb-2"
@@ -110,9 +110,31 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" integrity="sha512-pHVGpX7F/27yZ0ISY+VVjyULApbDlD0/X0rgGbTqCE7WFW5MezNTWG/dnhtbBuICzsd0WQPgpE4REBLv+UqChw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="assets/js/auth.js"></script>
     <link rel="modulepreload" href="build/assets/dashboard.css" /><script type="module" src="build/assets/dashboard.js" data-navigate-track="reload"></script>        <script>
+        function loginUser() {
+            const email = document.querySelector('input[name="email"]').value;
+            const password = document.querySelector('input[name="password"]').value;
+            const remember = document.querySelector('input[name="remember"]').checked;
+            if (Auth.login(email, password, remember)) {
+                window.location.href = 'index.html';
+            } else {
+                alert('Credenciais inválidas');
+            }
+        }
+
         document.addEventListener('DOMContentLoaded', () => {
             fadeOutToRight();
+
+            const form = document.getElementById('login-form');
+            form.addEventListener('submit', e => {
+                e.preventDefault();
+                loginUser();
+            });
+
+            if (Auth.isLoggedIn()) {
+                window.location.href = 'index.html';
+            }
 
             if (typeof Livewire !== 'undefined') {
                 Livewire.hook('commit.prepare', () => {

--- a/perfil.html
+++ b/perfil.html
@@ -33,8 +33,6 @@
                    autoplay
     />
 </div>
-            <form id="logout-form" action="login.html" method="POST" style="display: none;">
-            <input type="hidden" name="_token" value="lvZ2umWn1Kr8WsDLuis8QRNCGWmrF0q5OySqzNJB" autocomplete="off">        </form>
         <div id="pageWrapper" class="page-wrapper compact-wrapper">
     <!-- Navbar -->
 <nav class="page-main-header">
@@ -89,15 +87,13 @@
         <a title="Editar perfil" class="setting-primary" href="perfil.html">
             <i data-feather="settings"></i>
         </a>
-                <a title="Sair" class="setting-secondary"
-            onclick="event.preventDefault();document.getElementById('logout-form').submit();"
-            href="login.html">
+                <a title="Sair" class="setting-secondary" href="#" onclick="handleLogout()">
             <i data-feather="log-out"></i>
         </a>
         <img class="rounded-circle img-90" style="object-fit: cover;"
             src="perfil/119/foto">
         <a href="perfil.html">
-            <h6 class="mt-3 f-14 f-w-600">Gabriel França Dutra Simões</h6>
+            <h6 class="mt-3 f-14 f-w-600 user-name"></h6>
         </a>
         <p class="mb-0 font-roboto">T.I</p>
             </div>
@@ -171,7 +167,7 @@
                                     <label class="col-sm-2 col-form-label">Nome</label>
                                     <div class="col-sm-7">
                                         <div class="form-group">
-                                            <input class="form-control" name="name" id="input-name" type="text" placeholder="Digite o usuário" value="Gabriel França Dutra Simões" required="true" aria-required="true" />
+                                            <input class="form-control" name="name" id="input-name" type="text" placeholder="Digite o usuário" value="" required="true" aria-required="true" />
                                                                                     </div>
                                     </div>
                                 </div>
@@ -179,7 +175,7 @@
                                     <label class="col-sm-2 col-form-label">Email</label>
                                     <div class="col-sm-7">
                                         <div class="form-group">
-                                            <input class="form-control" name="email" id="input-email" type="email" placeholder="Digite o email do usuário" value="gabriel.simoes@unicv.edu.br" required />
+                                            <input class="form-control" name="email" id="input-email" type="email" placeholder="Digite o email do usuário" value="" required />
                                                                                     </div>
                                     </div>
                                 </div>
@@ -258,6 +254,33 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" integrity="sha512-pHVGpX7F/27yZ0ISY+VVjyULApbDlD0/X0rgGbTqCE7WFW5MezNTWG/dnhtbBuICzsd0WQPgpE4REBLv+UqChw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="assets/js/auth.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            requireAuth();
+            const form = document.querySelector('form');
+            if (form) {
+                form.addEventListener('submit', (e) => {
+                    e.preventDefault();
+                    const oldPass = document.getElementById('input-current-password').value;
+                    const newPass = document.getElementById('input-password').value;
+                    const confirmPass = document.getElementById('input-password-confirmation').value;
+                    if (newPass !== confirmPass) {
+                        alert('As senhas não coincidem');
+                        return;
+                    }
+                    if (Auth.changePassword(oldPass, newPass)) {
+                        alert('Senha alterada com sucesso');
+                        document.getElementById('input-current-password').value = '';
+                        document.getElementById('input-password').value = '';
+                        document.getElementById('input-password-confirmation').value = '';
+                    } else {
+                        alert('Senha atual incorreta');
+                    }
+                });
+            }
+        });
+    </script>
     <link rel="modulepreload" href="build/assets/dashboard.js" /><script type="module" src="build/assets/dashboard.js" data-navigate-track="reload"></script>        <script>
         document.addEventListener('DOMContentLoaded', () => {
             fadeOutToRight();


### PR DESCRIPTION
## Summary
- allow logins to be stored only for the session or permanently when "Lembrar de mim" is checked
- redirect remembered users straight to the dashboard and personalize greetings with their stored name

## Testing
- `npm test` *(fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/dashboard-unicv/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894d49830fc8320978ab99c473c367b